### PR TITLE
fix: Filter campaigns by date and enabled status in Aeco

### DIFF
--- a/src/aecos/app/iot-services/get-all-aeco-advertisings.service.ts
+++ b/src/aecos/app/iot-services/get-all-aeco-advertisings.service.ts
@@ -3,6 +3,7 @@ import {
   AECO_REPOSITORY,
   type IAecoRepository,
 } from '@shared/domain/repositories'
+import { currentDateTZ } from '@shared/utils/functions'
 import type { IAeco } from '@common/domain/entities'
 import type { DecodedAeco } from '@shared/domain/Types'
 import type { IGetAllAecoAdvertisingsService } from '@aecos/domain/services/iot-services/IGetAllAecoAdvertisingsService'
@@ -19,7 +20,11 @@ export class GetAllAecoAdvertisingsService
   ) {}
   async run(currentAeco: DecodedAeco): Promise<IAeco> {
     const { aecoId } = currentAeco
-    const aeco = await this.aecoRepository.getCampaignsByAeco(aecoId)
+    const currentDate = currentDateTZ()
+    const aeco = await this.aecoRepository.getCampaignsByAeco(
+      aecoId,
+      currentDate,
+    )
 
     if (!aeco) throw new NotFoundException('El Aeco no existe')
 

--- a/src/shared/domain/repositories/IAecoRepository.ts
+++ b/src/shared/domain/repositories/IAecoRepository.ts
@@ -27,7 +27,11 @@ export interface IAecoRepository {
     manager?: EntityManager,
   ): Promise<IAeco[]>
   getRewardsByAeco(id: number, manager?: EntityManager): Promise<IAeco | null>
-  getCampaignsByAeco(id: number, manager?: EntityManager): Promise<IAeco | null>
+  getCampaignsByAeco(
+    id: number,
+    currentDate: Date,
+    manager?: EntityManager,
+  ): Promise<IAeco | null>
   create(aeco: Partial<IAeco>, manager?: EntityManager): Promise<IAeco>
   partialUpdate(
     exists: IAeco,

--- a/src/shared/infra/repositories/AecoRepository.ts
+++ b/src/shared/infra/repositories/AecoRepository.ts
@@ -238,11 +238,18 @@ export class AecoRepository
 
   getCampaignsByAeco(
     id: number,
+    currentDate: Date,
     manager?: EntityManager,
   ): Promise<IAeco | null> {
-    return this.repository(manager)
+    const qb = this.repository(manager)
       .createQueryBuilder('aeco')
-      .leftJoinAndSelect('aeco.campaigns', 'campaigns')
+      .leftJoinAndSelect(
+        'aeco.campaigns',
+        'campaigns',
+        `campaigns.isEnabled = :isEnabled AND 
+        (campaigns.startDate <= :currentDate AND campaigns.endDate >= :currentDate)`,
+        { isEnabled: true, currentDate },
+      )
       .leftJoinAndSelect('campaigns.contractor', 'contractor')
       .leftJoinAndSelect('campaigns.mediaAsset', 'mediaAsset')
       .select([
@@ -272,7 +279,7 @@ export class AecoRepository
       .andWhere('aeco.status = :status', {
         status: AecoStatusEnum.ENABLED,
       })
-      .getOne()
+    return qb.getOne()
   }
 
   create(aeco: Partial<IAeco>, manager?: EntityManager): Promise<IAeco> {


### PR DESCRIPTION
Updated getCampaignsByAeco to accept currentDate and filter campaigns by enabled status and active date range. Adjusted service and repository interface to support the new parameters and query logic.