### PR TITLE
feat: Add companyName filter to contractor search

### DIFF
--- a/src/advertisings/domain/dto/Filters.dto.ts
+++ b/src/advertisings/domain/dto/Filters.dto.ts
@@ -30,6 +30,17 @@ export class ContractorFiltersDto extends BaseFiltersDto {
   readonly companyId?: number
 
   @ApiPropertyOptional({
+    description: 'Filtrar por nombre de la compañía',
+    example: 'empresa',
+  })
+  @IsOptional()
+  @IsString({ message: 'companyName debe ser una cadena de texto' })
+  @Transform(({ value }) =>
+    value ? normalizeString(value.toLowerCase()) : value,
+  )
+  readonly companyName?: string
+
+  @ApiPropertyOptional({
     description: 'Filtrar por nombre del contratista',
     example: 'juan',
   })

--- a/src/shared/infra/repositories/ContractorRepository.ts
+++ b/src/shared/infra/repositories/ContractorRepository.ts
@@ -77,6 +77,12 @@ export class ContractorRepository
       })
     }
 
+    if (filters?.companyName) {
+      qb.andWhere('LOWER(unaccent(BTRIM(company.name))) ILIKE :companyName', {
+        companyName: `%${filters.companyName}%`,
+      })
+    }
+
     if (filters?.name) {
       qb.andWhere('LOWER(unaccent(BTRIM(contractors.name))) ILIKE :name', {
         name: `%${filters.name}%`,


### PR DESCRIPTION
Introduces an optional companyName filter to ContractorFiltersDto and updates ContractorRepository to support filtering contractors by normalized, case-insensitive company name.