### PR TITLE
fix: Refactor role lookup to remove token parameter

### DIFF
--- a/src/auth/app/jwt/jwt.service.ts
+++ b/src/auth/app/jwt/jwt.service.ts
@@ -37,9 +37,8 @@ export class JwtService implements IJwtService {
   async verify(token: string): Promise<DecodedUser> {
     try {
       const decoded = jwt.verify(token, this.secret) as DecodedUser
-      const role = await this.roleRepository.findByApiKeyAndToken(
+      const role = await this.roleRepository.findByApiKey(
         decoded.sub,
-        token,
         decoded.roleType,
       )
 

--- a/src/shared/domain/repositories/IRoleRepository.ts
+++ b/src/shared/domain/repositories/IRoleRepository.ts
@@ -9,9 +9,8 @@ export interface IRoleRepository {
     id: number,
     manager?: EntityManager,
   ): Promise<IUserRolePermissions | null>
-  findByApiKeyAndToken(
+  findByApiKey(
     apiKey: string,
-    token?: string,
     type?: UserRoleEntiyEnum,
     manager?: EntityManager,
   ): Promise<IUserRolePermissions | null>

--- a/src/shared/infra/repositories/RoleRepository.ts
+++ b/src/shared/infra/repositories/RoleRepository.ts
@@ -29,9 +29,8 @@ export class RoleRepository
     })
   }
 
-  findByApiKeyAndToken(
+  findByApiKey(
     apiKey: string,
-    token?: string,
     type?: UserRoleEntiyEnum,
     manager?: EntityManager,
   ): Promise<IUserRolePermissions | null> {
@@ -54,10 +53,6 @@ export class RoleRepository
       .andWhere('role.deletedAt IS NULL')
       .andWhere('user.deletedAt IS NULL AND user.isActive = true')
       .andWhere('company.deletedAt IS NULL')
-
-    if (token) {
-      qb.andWhere('role.token = :token', { token })
-    }
 
     if (type) {
       qb.andWhere('role.role = :type', { type })


### PR DESCRIPTION
Updated the role repository interface and implementation to remove the token parameter from the findByApiKey method. Adjusted JwtService to use the new method signature, simplifying role retrieval logic.