### PR TITLE
hotfix: Add global caching with CacheInterceptor in NestJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.658.1",
         "@aws-sdk/s3-request-presigner": "^3.658.1",
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.2",
         "@nestjs/core": "^10.0.0",
@@ -21,6 +22,7 @@
         "@nestjs/typeorm": "^10.0.2",
         "@types/luxon": "^3.6.2",
         "bcrypt": "^5.1.1",
+        "cache-manager": "^7.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "crypto-js": "^4.2.0",
@@ -31,7 +33,7 @@
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
         "pg": "8.11.5",
-        "postmark": "^4.0.5",
+        "postmark": "4.0.5",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.20",
@@ -2313,6 +2315,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g=="
+    },
     "node_modules/@ljharb/through": {
       "version": "2.3.14",
       "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.14.tgz",
@@ -2356,6 +2363,18 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
       "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw=="
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz",
+      "integrity": "sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
+      }
     },
     "node_modules/@nestjs/cli": {
       "version": "10.4.9",
@@ -4973,6 +4992,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.1.1.tgz",
+      "integrity": "sha512-YZ5CXZ4cNOcVH5bokYE1Bo5NARvJhOkYAAwImGf7DozC0uyrT5Jqd5AWfPnSRavlHTPiHp2yZL3Q3ZEWBfkQvQ==",
+      "dependencies": {
+        "keyv": "^5.5.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -6506,6 +6533,15 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/flatted": {
@@ -8349,12 +8385,11 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
+      "integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.0"
       }
     },
     "node_modules/kleur": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.658.1",
     "@aws-sdk/s3-request-presigner": "^3.658.1",
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.2",
     "@nestjs/core": "^10.0.0",
@@ -41,6 +42,7 @@
     "@nestjs/typeorm": "^10.0.2",
     "@types/luxon": "^3.6.2",
     "bcrypt": "^5.1.1",
+    "cache-manager": "^7.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "crypto-js": "^4.2.0",

--- a/src/aecos/infra/controllers/iot-controllers/get-access-control-aeco.controller.ts
+++ b/src/aecos/infra/controllers/iot-controllers/get-access-control-aeco.controller.ts
@@ -7,7 +7,9 @@ import {
   Inject,
   Logger,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common'
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager'
 import {
   ACCESS_CONTROL_AECO_SERVICE,
   type IAccessControlAecoService,
@@ -27,6 +29,8 @@ export class GetAccessControlAecoController {
   ) {}
 
   @Get('access-control')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60)
   @UseGuards(AccessControlAecosGuard)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,8 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common'
+import { APP_INTERCEPTOR } from '@nestjs/core'
+import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager'
 import { AecosModule } from '@aecos/aecos.module'
 import { AdvertisingsModule } from '@advertisings/advertisings.module'
 import { AppController } from './app.controller'
@@ -23,6 +25,9 @@ import { UsersModule } from '@users/users.module'
 
 @Module({
   imports: [
+    CacheModule.register({
+      isGlobal: true,
+    }),
     SharedModule,
     CommonModule,
     UsersModule,
@@ -37,7 +42,13 @@ import { UsersModule } from '@users/users.module'
     TicketsModule,
     AdvertisingsModule,
   ],
-  providers: [AppService],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CacheInterceptor,
+    },
+    AppService,
+  ],
   controllers: [AppController],
 })
 export class AppModule implements NestModule {


### PR DESCRIPTION
Introduced @nestjs/cache-manager and cache-manager dependencies. Configured CacheModule as a global module in AppModule and set up CacheInterceptor as a global interceptor. Applied CacheInterceptor and a 60-second TTL to the access control endpoint in GetAccessControlAecoController to improve performance by caching responses.